### PR TITLE
Fix: Display C7 as n/a and exclude from composite when --no-llm is set

### DIFF
--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -47,6 +47,7 @@ type HTMLCategory struct {
 	DisplayName       string
 	Score             float64
 	ScoreClass        string // "ready", "assisted", "limited"
+	Available         bool   // whether category data is available
 	SubScores         []HTMLSubScore
 	ImpactDescription string
 	Citations         []Citation // Per-category citations
@@ -186,6 +187,7 @@ func buildHTMLCategories(categories []types.CategoryScore, citations []Citation,
 			DisplayName:       categoryDisplayName(cat.Name),
 			Score:             cat.Score,
 			ScoreClass:        scoreToClass(cat.Score),
+			Available:         cat.Score >= 0, // Infer from score
 			SubScores:         buildHTMLSubScores(cat.Name, cat.SubScores, trace),
 			ImpactDescription: categoryImpact(cat.Name),
 			Citations:         filterCitationsByCategory(citations, cat.Name),

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -22,8 +22,9 @@ type JSONReport struct {
 // JSONCategory represents a scoring category in JSON output.
 type JSONCategory struct {
 	Name      string       `json:"name"`
-	Score     float64      `json:"score"`
+	Score     float64      `json:"score"`     // -1.0 when unavailable
 	Weight    float64      `json:"weight"`
+	Available bool         `json:"available"` // whether category is available
 	SubScores []JSONMetric `json:"sub_scores"`
 }
 
@@ -56,7 +57,7 @@ type JSONRecommendation struct {
 // When includeBadge is true, badge URL and markdown are included.
 func BuildJSONReport(scored *types.ScoredResult, recs []recommend.Recommendation, verbose bool, includeBadge bool) *JSONReport {
 	report := &JSONReport{
-		Version:        "2",
+		Version:        "3",
 		CompositeScore: scored.Composite,
 		Tier:           scored.Tier,
 	}
@@ -66,6 +67,7 @@ func BuildJSONReport(scored *types.ScoredResult, recs []recommend.Recommendation
 			Name:      cat.Name,
 			Score:     cat.Score,
 			Weight:    cat.Weight,
+			Available: cat.Score >= 0, // Infer from score
 			SubScores: make([]JSONMetric, 0, len(cat.SubScores)),
 		}
 

--- a/internal/output/templates/report.html
+++ b/internal/output/templates/report.html
@@ -64,7 +64,7 @@
         </div>
         {{range .Categories}}
         <div class="category">
-            <h2>{{.DisplayName}} <span class="cat-score score-{{.ScoreClass}}">{{printf "%.1f" .Score}}/10</span></h2>
+            <h2>{{.DisplayName}} {{if .Available}}<span class="cat-score score-{{.ScoreClass}}">{{printf "%.1f" .Score}}/10</span>{{else}}<span class="cat-score unavailable">n/a</span>{{end}}</h2>
             <table class="metric-table">
                 <thead>
                     <tr>

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -682,6 +682,12 @@ func RenderScores(w io.Writer, scored *types.ScoredResult, verbose bool) {
 		}
 		label := fmt.Sprintf("%s: %-20s", cat.Name, displayName)
 
+		// Check for unavailable category
+		if cat.Score < 0 {
+			color.New(color.FgHiBlack).Fprintf(w, "  %sn/a\n", label)
+			continue
+		}
+
 		sc := scoreColor(cat.Score)
 		sc.Fprintf(w, "  %s%.1f / 10\n", label, cat.Score)
 

--- a/internal/scoring/scorer.go
+++ b/internal/scoring/scorer.go
@@ -112,8 +112,8 @@ func (s *Scorer) classifyTier(score float64) string {
 
 // CategoryScore computes the weighted average of sub-scores within a category.
 // Sub-scores where Available == false are excluded, and their weight is
-// redistributed among the remaining sub-scores. Returns 0.0 if no sub-scores
-// are available (indicating a disabled/unavailable category).
+// redistributed among the remaining sub-scores. Returns -1.0 if no sub-scores
+// are available, signaling the category should be excluded from composite scoring.
 func CategoryScore(subScores []types.SubScore) float64 {
 	totalWeight := 0.0
 	weightedSum := 0.0
@@ -127,7 +127,7 @@ func CategoryScore(subScores []types.SubScore) float64 {
 	}
 
 	if totalWeight == 0 {
-		return 0.0 // Disabled capabilities show 0/10
+		return -1.0 // Mark category as unavailable (excluded from composite)
 	}
 	return weightedSum / totalWeight
 }

--- a/internal/scoring/scorer_test.go
+++ b/internal/scoring/scorer_test.go
@@ -235,8 +235,8 @@ func TestCategoryScore_SkipUnavailable(t *testing.T) {
 
 func TestCategoryScore_Empty(t *testing.T) {
 	got := CategoryScore(nil)
-	if got != 0.0 {
-		t.Errorf("CategoryScore(nil) = %v, want 0.0", got)
+	if got != -1.0 {
+		t.Errorf("CategoryScore(nil) = %v, want -1.0", got)
 	}
 }
 
@@ -246,8 +246,8 @@ func TestCategoryScore_AllUnavailable(t *testing.T) {
 		{MetricName: "b", Score: 0, Weight: 0.5, Available: false},
 	}
 	got := CategoryScore(subs)
-	if got != 0.0 {
-		t.Errorf("CategoryScore(all unavailable) = %v, want 0.0", got)
+	if got != -1.0 {
+		t.Errorf("CategoryScore(all unavailable) = %v, want -1.0", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

When users run `ars scan` with the `--no-llm` flag, C7 (Agent Evaluation) metrics were being assigned a score of 0.0/10 instead of being marked as unavailable. This incorrectly pulled down the overall composite score and made it appear as though the codebase had a terrible agent evaluation score rather than indicating the feature was unavailable.

**Before:**
- C7 metrics returned `Available: false` when `--no-llm` was set
- Category score was calculated as 0.0 (not -1.0)
- This 0.0 score was INCLUDED in composite calculation, reducing overall score
- Terminal showed "Not available" in details, but numeric outputs showed 0.0/10

## Solution

Changed the scoring logic to use -1.0 as a sentinel value for unavailable categories, which the composite calculation already knows to skip. This approach:

1. Reuses existing logic in `computeComposite()` that checks `if cat.Score < 0`
2. Redistributes the unavailable category's weight among remaining categories
3. Works for any unavailable category (C5 when no .git, C7 when --no-llm)

## Changes

- **scoring**: `CategoryScore()` now returns -1.0 for unavailable categories
- **terminal**: Display "n/a" for categories with score < 0
- **json**: Add `Available` field to `JSONCategory`, bump schema to v3
- **html**: Add `Available` field to `HTMLCategory`, render "n/a" in template
- **tests**: Update tests to expect -1.0 for unavailable categories

## Verification

✅ Terminal output: Shows "C7: Agent Evaluation    n/a" when --no-llm is set
✅ JSON output: Shows `"score": -1`, `"available": false`, schema version "3"
✅ HTML output: Displays "n/a" with unavailable styling
✅ Composite score: Correctly excludes C7 and redistributes weight to remaining 6 categories
✅ Unit tests: All 40+ tests pass
✅ Regression: C7 still works normally when LLM is enabled

## Example

**With --no-llm flag:**
```
C1: Code Health         6.5 / 10
C2: Semantic Explicitness8.1 / 10
C3: Architecture        7.2 / 10
C4: Documentation Quality8.5 / 10
C5: Temporal Dynamics   6.3 / 10
C6: Testing             9.3 / 10
C7: Agent Evaluation    n/a
────────────────────────────────────────
Composite Score:          7.6 / 10
```

**JSON Schema (v3):**
```json
{
  "name": "C7",
  "score": -1,
  "weight": 0.1,
  "available": false,
  "sub_scores": [...]
}
```

## Breaking Changes

- JSON schema version bumped from "2" to "3"
- The `Available` field is additive (doesn't break existing parsers)
- Score value changing from 0.0 to -1.0 is a bug fix that makes data more accurate