### PR TITLE
fix: `go install` fails — `cmd/ars` missing in v0.0.7 (#73)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release Verification
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Verify go build
+        run: go build ./cmd/ars
+
+      - name: Verify go install
+        run: go install ./cmd/ars
+
+      - name: Run tests
+        run: go test ./... -count=1
+
+      - name: Run vet
+        run: go vet ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-03-12
+
+### Fixed
+- `go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@latest` now works (#73)
+  - v0.0.7 was tagged before `cmd/ars/main.go` restructuring (commit 274b5f6)
+  - This release includes the `cmd/ars` entry point so `go install` resolves correctly
+
+### Added
+- Repository metadata metrics in analysis output (#71)
+- Release verification CI workflow — runs `go build ./cmd/ars` on every tag push
+- `RELEASING.md` — release checklist with `go install` verification steps
+
+### Changed
+- Top-5 refactoring for maximum code quality (#72)
+- Analyzer language files renamed to match naming convention (#70)
+- C5 N/A in benchmark and report generator fixed (#69)
+- Average function length reduced from 26.9 to 17.4 lines
+- Scorer and terminal split into per-category modules
+- Shared helpers extracted to reduce code duplication (15.3% to 14.4%)
+- `cmd/` package test coverage added (76.7% coverage)
+
+## [0.0.7] - 2026-02-28
+
+### Added
+- Architecture diagrams for C4 documentation score improvement
+- Selective category/metric execution ticket
+- Unit tests for agent evaluator core logic
+- Error path tests for C7 analyzer
+- Tests for output rendering, type methods, shared utilities, and pipeline setters
+
+### Changed
+- Consolidated LLM control under single `--no-llm` flag (replaces separate C4/C7 flags)
+- C7 displays as n/a and excluded from composite when `--no-llm` is set
+- Module path corrected in go.mod (#63)
+- Internal APIs unexported and agent documentation consolidated
+- Duplication detection thresholds consolidated to reduce magic numbers
+- Code structure and comment density improved for Agent-Ready tier
+- Doc comments added to all exported metric methods and analyzer type aliases
+- `map[string]interface{}` replaced with typed `CategoryMetrics` interface
+
+### Removed
+- 6 unnecessary shared utility exports from `internal/analyzer`
+- 3 unnecessary type exports from `internal/analyzer/c2_semantics`
+- `StubAnalyzer` export from `internal/pipeline`
+- Unused `DefaultProjectConfig` from `internal/config`
+- 2 unnecessary exports from `internal/scoring`
+- Unused `ParsedFile` type from `pkg/types`
+- 3 unnecessary function exports from `internal/discovery`
+- 6 unnecessary type exports from `internal/output`
+
 ## [0.0.6] - 2026-02-07
 
 ### Added
@@ -246,7 +296,9 @@ Initial release of Agent Readiness Score (ARS) - a CLI tool that measures codeba
   - Effort level classification (Low/Medium/High)
   - Agent-readiness framing
 
-[Unreleased]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.8...HEAD
+[0.0.8]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/ingo-eichhorst/agent-readyness/compare/v0.0.3...v0.0.4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing
+
+Release checklist for Agent Readiness Score (ARS).
+
+## Pre-release
+
+1. **All tests pass**
+   ```bash
+   go test ./... -count=1
+   ```
+
+2. **Build succeeds**
+   ```bash
+   go build ./cmd/ars
+   ```
+
+3. **`go install` works locally**
+   ```bash
+   go install ./cmd/ars
+   ars --help
+   ```
+
+4. **CHANGELOG.md updated**
+   - New version section added between `[Unreleased]` and previous version
+   - Comparison links updated at bottom of file
+
+5. **No uncommitted changes**
+   ```bash
+   git status
+   ```
+
+## Tag and push
+
+1. **Create annotated tag**
+   ```bash
+   git tag -a v0.0.X -m "Release v0.0.X"
+   ```
+
+2. **Push tag**
+   ```bash
+   git push origin v0.0.X
+   ```
+
+3. **Verify CI** — the `release.yml` workflow runs automatically on tag push and checks:
+   - `go build ./cmd/ars`
+   - `go install ./cmd/ars`
+   - `go test ./...`
+   - `go vet ./...`
+
+## Post-release verification
+
+1. **Wait for Go module proxy** (up to 5 minutes)
+   ```bash
+   GOPROXY=https://proxy.golang.org go list -m github.com/ingo-eichhorst/agent-readyness@v0.0.X
+   ```
+
+2. **Verify `go install` from a clean environment**
+   ```bash
+   cd $(mktemp -d)
+   go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@v0.0.X
+   ars --help
+   ```
+
+3. **Check GitHub release page** — confirm the tag appears at
+   https://github.com/ingo-eichhorst/agent-readyness/releases
+
+## What can go wrong
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `go install ...@vX` fails with "no matching versions" | Tag pushed before `cmd/ars/main.go` existed | Tag a new release that includes `cmd/ars/` (see #73) |
+| CI release workflow fails | Build or test broken at tagged commit | Fix, re-tag with next patch version |
+| Module proxy serves stale version | Caching delay | Wait 5 minutes, then `GONOSUMCHECK=* go install ...` |


### PR DESCRIPTION
## Summary
- **Root cause:** v0.0.7 was tagged before `cmd/ars/main.go` restructuring (commit 274b5f6), so `go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@latest` fails
- Adds missing v0.0.7 changelog entry + new v0.0.8 entry to `CHANGELOG.md`
- Creates `RELEASING.md` with release checklist including `go install` verification
- Adds `.github/workflows/release.yml` CI workflow that verifies `go build/install ./cmd/ars` on every tag push

## Verification
```bash
git show v0.0.7:cmd/ars/main.go   # fails — confirms root cause
go build ./cmd/ars                 # succeeds on this branch
go test ./... -count=1             # all tests pass
```

## Test plan
- [x] `go build ./cmd/ars` succeeds
- [x] `go test ./...` passes
- [ ] After merge + v0.0.8 tag: `go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@v0.0.8` works
- [ ] Release CI workflow triggers on tag push

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)