### PR TITLE
benchmark: update expected_score_range to v3 actuals (ar-je7)

### DIFF
--- a/benchmark/benchmark.yaml
+++ b/benchmark/benchmark.yaml
@@ -14,7 +14,7 @@ repos:
     commit: "v1.10.0"
     size: large
     expected_quality: high
-    expected_score_range: [7, 8]
+    expected_score_range: [7, 9]
 
   - name: lo
     language: go
@@ -30,7 +30,7 @@ repos:
     commit: "v1.20.1"
     size: medium
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [7, 8]
 
   - name: colly
     language: go
@@ -38,7 +38,7 @@ repos:
     commit: "v2.1.0"
     size: medium
     expected_quality: medium
-    expected_score_range: [5, 6]
+    expected_score_range: [7, 8]
 
   - name: badger
     language: go
@@ -46,7 +46,7 @@ repos:
     commit: "v4.7.0"
     size: large
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [7, 8]
 
   - name: resty
     language: go
@@ -54,7 +54,7 @@ repos:
     commit: "v2.16.5"
     size: medium
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [7, 8]
 
   - name: uuid
     language: go
@@ -62,7 +62,7 @@ repos:
     commit: "v1.6.0"
     size: tiny
     expected_quality: medium
-    expected_score_range: [4, 6]
+    expected_score_range: [8, 9]
 
   - name: go-humanize
     language: go
@@ -70,7 +70,7 @@ repos:
     commit: "v1.0.1"
     size: tiny
     expected_quality: low
-    expected_score_range: [3, 5]
+    expected_score_range: [7, 9]
 
   - name: color
     language: go
@@ -78,7 +78,7 @@ repos:
     commit: "v1.18.0"
     size: tiny
     expected_quality: low
-    expected_score_range: [3, 5]
+    expected_score_range: [8, 9]
 
   # Go upper boundary: high test coverage, Google-maintained, excellent docs
   - name: grpc-go
@@ -87,7 +87,7 @@ repos:
     commit: "v1.63.0"
     size: large
     expected_quality: very_high
-    expected_score_range: [8, 10]
+    expected_score_range: [6, 8]
 
   # Go lower boundary: stagnant since 2021, no tests, sparse docs
   - name: gg
@@ -96,7 +96,7 @@ repos:
     commit: "main"
     size: small
     expected_quality: very_low
-    expected_score_range: [1, 4]
+    expected_score_range: [6, 8]
 
   # Python repos: tiny → large, high → low quality
   - name: pydantic
@@ -105,7 +105,7 @@ repos:
     commit: "v2.10.6"
     size: large
     expected_quality: high
-    expected_score_range: [7, 9]
+    expected_score_range: [6, 7]
 
   - name: httpx
     language: python
@@ -113,7 +113,7 @@ repos:
     commit: "0.28.1"
     size: medium
     expected_quality: high
-    expected_score_range: [7, 8]
+    expected_score_range: [7, 9]
 
   - name: rich
     language: python
@@ -137,7 +137,7 @@ repos:
     commit: "0.15.2"
     size: small
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [7, 8]
 
   - name: more-itertools
     language: python
@@ -153,7 +153,7 @@ repos:
     commit: "v4.67.1"
     size: medium
     expected_quality: medium
-    expected_score_range: [4, 6]
+    expected_score_range: [5, 7]
 
   - name: python-dateutil
     language: python
@@ -161,7 +161,7 @@ repos:
     commit: "2.9.0.post0"
     size: small
     expected_quality: low
-    expected_score_range: [3, 5]
+    expected_score_range: [6, 7]
 
   - name: python-slugify
     language: python
@@ -169,7 +169,7 @@ repos:
     commit: "8.0.4"
     size: tiny
     expected_quality: low
-    expected_score_range: [2, 4]
+    expected_score_range: [6, 7]
 
   - name: result
     language: python
@@ -177,7 +177,7 @@ repos:
     commit: "0.17.0"
     size: tiny
     expected_quality: low
-    expected_score_range: [3, 5]
+    expected_score_range: [8, 9]
 
   # Python upper boundary: legendary docs, comprehensive tests, clean API design
   - name: requests
@@ -186,7 +186,7 @@ repos:
     commit: "v2.32.3"
     size: medium
     expected_quality: very_high
-    expected_score_range: [8, 10]
+    expected_score_range: [6, 8]
 
   # Python lower boundary: legacy character detection port, no type hints, complex logic
   - name: chardet
@@ -195,7 +195,7 @@ repos:
     commit: "5.2.0"
     size: small
     expected_quality: very_low
-    expected_score_range: [1, 4]
+    expected_score_range: [4, 6]
 
   # TypeScript repos: tiny → large, high → low quality
   - name: zod
@@ -204,7 +204,7 @@ repos:
     commit: "v3.24.2"
     size: medium
     expected_quality: high
-    expected_score_range: [7, 9]
+    expected_score_range: [6, 8]
 
   - name: kysely
     language: typescript
@@ -212,7 +212,7 @@ repos:
     commit: "0.27.5"
     size: medium
     expected_quality: high
-    expected_score_range: [7, 8]
+    expected_score_range: [6, 7]
 
   - name: date-fns
     language: typescript
@@ -228,7 +228,7 @@ repos:
     commit: "v5.6.2"
     size: small
     expected_quality: high
-    expected_score_range: [7, 8]
+    expected_score_range: [6, 7]
 
   - name: effect
     language: typescript
@@ -236,7 +236,7 @@ repos:
     commit: "effect@3.13.6"
     size: large
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [6, 7]
 
   - name: fast-check
     language: typescript
@@ -244,7 +244,7 @@ repos:
     commit: "v3.23.2"
     size: medium
     expected_quality: medium
-    expected_score_range: [5, 7]
+    expected_score_range: [6, 7]
 
   - name: superjson
     language: typescript
@@ -252,7 +252,7 @@ repos:
     commit: "v2.2.2"
     size: small
     expected_quality: medium
-    expected_score_range: [5, 6]
+    expected_score_range: [7, 8]
 
   - name: changesets
     language: typescript
@@ -260,7 +260,7 @@ repos:
     commit: "v2.28.1"
     size: medium
     expected_quality: medium
-    expected_score_range: [4, 6]
+    expected_score_range: [6, 7]
 
   - name: nanoid
     language: typescript
@@ -268,7 +268,7 @@ repos:
     commit: "5.1.5"
     size: tiny
     expected_quality: low
-    expected_score_range: [3, 5]
+    expected_score_range: [7, 8]
 
   - name: ms
     language: typescript
@@ -276,7 +276,7 @@ repos:
     commit: "6ec025f7e35899c436aaa0fbac57657af81467d3"
     size: tiny
     expected_quality: low
-    expected_score_range: [2, 4]
+    expected_score_range: [7, 9]
 
   # TypeScript upper boundary: small, fully typed, comprehensive tests, active
   - name: zustand
@@ -285,7 +285,7 @@ repos:
     commit: "v4.5.5"
     size: small
     expected_quality: very_high
-    expected_score_range: [8, 10]
+    expected_score_range: [7, 8]
 
   # TypeScript lower boundary: archived 2018 Polymer project, no tests, legacy
   - name: prpl-server
@@ -294,4 +294,4 @@ repos:
     commit: "v3.1.0"
     size: small
     expected_quality: very_low
-    expected_score_range: [1, 4]
+    expected_score_range: [6, 7]


### PR DESCRIPTION
## Summary

Updates all `expected_score_range` values in `benchmark/benchmark.yaml` to reflect v3 benchmark actuals.

**Key corrections (aspirational → actual):**
- `very_high` repos (grpc-go, requests, zustand): `[8, 10]` → `[6, 8]` / `[7, 8]` (actual scores: 7.04, 7.07, 7.68)
- `very_low` repos (gg, prpl-server, chardet): `[1, 4]` → `[6, 8]` / `[4, 6]` (actual scores: 6.87, 6.70, 5.09)
- Low-quality tiny repos (color, go-humanize, ms, nanoid, result): `[2, 5]` → `[7, 9]` (these repos actually score well despite low community activity)

**Why this matters:** The original ranges implied a 1–10 effective spread that doesn't exist. The v3 benchmark (36 repos, post C1/C2/C5/C6 fixes) shows an actual range of 5.09–8.65. Ranges now accurately reflect what the current scoring algorithm produces.

**Field is documentation-only** — `benchmark_test.go` parses `ExpectedScoreRange` but never asserts against it. Tests compare against golden files.

Closes ar-je7 | Follow-up from ar-4z3 (GH#77)

## Test plan

- [ ] Verify `go build ./benchmark/...` passes (struct field still present)
- [ ] No golden file changes needed