### PR TITLE
fix(c4): walk to git root for doc-presence checks (#79)

### DIFF
--- a/internal/analyzer/c4_documentation/documentation.go
+++ b/internal/analyzer/c4_documentation/documentation.go
@@ -106,12 +106,49 @@ func (a *C4Analyzer) Analyze(targets []*types.AnalysisTarget) (*types.AnalysisRe
 }
 
 // analyzeStaticDocs checks for presence of documentation artifacts (README, CHANGELOG, etc.).
+//
+// When the scan target is a subdirectory of a git repo, also consults the git toplevel
+// so that root-level docs (the conventional location for polyglot/multi-module repos)
+// are not reported as missing. Scan-dir hits take precedence over git-root hits.
 func analyzeStaticDocs(rootDir string, metrics *types.C4Metrics) {
-	metrics.ReadmePresent, metrics.ReadmeWordCount = analyzeReadme(rootDir)
-	metrics.ChangelogPresent = analyzeChangelog(rootDir)
-	metrics.ExamplesPresent = analyzeExamples(rootDir)
-	metrics.ContributingPresent = analyzeContributing(rootDir)
-	metrics.DiagramsPresent = analyzeDiagrams(rootDir)
+	searchDirs := []string{rootDir}
+	if gitRoot := findGitRoot(rootDir); gitRoot != "" && gitRoot != rootDir {
+		searchDirs = append(searchDirs, gitRoot)
+	}
+	for _, dir := range searchDirs {
+		if !metrics.ReadmePresent {
+			metrics.ReadmePresent, metrics.ReadmeWordCount = analyzeReadme(dir)
+		}
+		if !metrics.ChangelogPresent {
+			metrics.ChangelogPresent = analyzeChangelog(dir)
+		}
+		if !metrics.ExamplesPresent {
+			metrics.ExamplesPresent = analyzeExamples(dir)
+		}
+		if !metrics.ContributingPresent {
+			metrics.ContributingPresent = analyzeContributing(dir)
+		}
+		if !metrics.DiagramsPresent {
+			metrics.DiagramsPresent = analyzeDiagrams(dir)
+		}
+	}
+}
+
+// findGitRoot walks up from start looking for a .git entry (directory or file,
+// to support git worktrees where .git is a file pointing to the worktree's gitdir).
+// Returns "" if no .git is found before reaching the filesystem root.
+func findGitRoot(start string) string {
+	dir := start
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // analyzeCodeMetrics computes comment density and API doc coverage across all language targets.

--- a/internal/analyzer/c4_documentation/documentation_test.go
+++ b/internal/analyzer/c4_documentation/documentation_test.go
@@ -222,6 +222,132 @@ func TestAnalyzeDiagrams(t *testing.T) {
 	}
 }
 
+func TestFindGitRoot(t *testing.T) {
+	// Layout: parent/.git/  parent/sub/nested/
+	parent := t.TempDir()
+	if err := os.Mkdir(filepath.Join(parent, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(parent, "sub", "nested")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findGitRoot(nested); got != parent {
+		t.Errorf("findGitRoot(nested) = %q, want %q", got, parent)
+	}
+	if got := findGitRoot(parent); got != parent {
+		t.Errorf("findGitRoot(parent) = %q, want %q", got, parent)
+	}
+
+	// .git as a file (git worktree style).
+	wtParent := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wtParent, ".git"), []byte("gitdir: /tmp/x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := findGitRoot(wtParent); got != wtParent {
+		t.Errorf("findGitRoot(.git as file) = %q, want %q", got, wtParent)
+	}
+}
+
+func TestAnalyzeStaticDocs_GitRootFallback(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.Mkdir(filepath.Join(parent, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"README.md", "CHANGELOG.md", "CONTRIBUTING.md"} {
+		if err := os.WriteFile(filepath.Join(parent, name), []byte("# "+name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(parent, "examples"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	docs := filepath.Join(parent, "docs")
+	if err := os.Mkdir(docs, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docs, "architecture-diagram.png"), []byte("PNG"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(parent, "core")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := &types.C4Metrics{}
+	analyzeStaticDocs(sub, metrics)
+
+	if !metrics.ReadmePresent {
+		t.Error("ReadmePresent: want true (root README should be detected)")
+	}
+	if metrics.ReadmeWordCount == 0 {
+		t.Error("ReadmeWordCount: want > 0 when root README is found")
+	}
+	if !metrics.ChangelogPresent {
+		t.Error("ChangelogPresent: want true")
+	}
+	if !metrics.ContributingPresent {
+		t.Error("ContributingPresent: want true")
+	}
+	if !metrics.ExamplesPresent {
+		t.Error("ExamplesPresent: want true (examples/ at root)")
+	}
+	if !metrics.DiagramsPresent {
+		t.Error("DiagramsPresent: want true (docs/architecture-diagram.png at root)")
+	}
+}
+
+func TestAnalyzeStaticDocs_ScanDirTakesPrecedence(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.Mkdir(filepath.Join(parent, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("root readme one two three"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(parent, "core")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	subReadme := "scan dir readme with notably more words than the root readme has"
+	if err := os.WriteFile(filepath.Join(sub, "README.md"), []byte(subReadme), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := &types.C4Metrics{}
+	analyzeStaticDocs(sub, metrics)
+
+	wantWords := countWords(subReadme)
+	if metrics.ReadmeWordCount != wantWords {
+		t.Errorf("ReadmeWordCount = %d, want %d (scan-dir README must win over git-root README)", metrics.ReadmeWordCount, wantWords)
+	}
+}
+
+func TestAnalyzeStaticDocs_NoFallbackOutsideRepo(t *testing.T) {
+	// Create a chain of empty dirs with no .git anywhere; findGitRoot should
+	// return "" and analyzeStaticDocs should not invent presence.
+	parent := t.TempDir()
+	sub := filepath.Join(parent, "core")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: parent of t.TempDir() can occasionally be inside a git repo on
+	// the developer machine. Skip if so to keep the test hermetic.
+	if findGitRoot(sub) != "" {
+		t.Skip("ambient git repo above TempDir would mask the no-fallback case")
+	}
+
+	metrics := &types.C4Metrics{}
+	analyzeStaticDocs(sub, metrics)
+
+	if metrics.ReadmePresent || metrics.ChangelogPresent || metrics.ContributingPresent ||
+		metrics.ExamplesPresent || metrics.DiagramsPresent {
+		t.Errorf("expected all flags false outside a git repo, got %+v", metrics)
+	}
+}
+
 func TestAnalyzeGoComments(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Closes #79.
- `ars scan <subdir>` now also consults the git toplevel for README/CHANGELOG/CONTRIBUTING/examples/diagrams presence, so polyglot repos (Go module in `./core`, docs at root) no longer get false-negative recommendations and a depressed C4.
- Scan-dir hits take precedence over git-root hits, so module-local docs (when present) still describe the scanned module.
- New helper `findGitRoot` walks parents for a `.git` entry — handles directories and files (git worktrees).

## Test plan
- [x] `go test ./internal/analyzer/c4_documentation/...` (3 new tests + existing tests pass)
- [x] `go test ./...` (full suite green)
- [x] `go build ./...`
- [x] E2E against `ingo-eichhorst/Irrlicht`: composite **7.74**, C4 **9.58/10**, all five doc signals = 1
- [x] Sanity: `ars scan .` (scan dir == git root) → no double-counting, scores unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)